### PR TITLE
Fix WS_NOT_OPEN error

### DIFF
--- a/app/vc.js
+++ b/app/vc.js
@@ -1,5 +1,7 @@
+const WebSocket = require('ws');
 const EventEmitter = require('events');
 const fastq = require('fastq');
+const utils = require('./utils');
 
 class VoiceChannel extends EventEmitter {
   constructor() {
@@ -19,24 +21,43 @@ class VoiceChannel extends EventEmitter {
         done(new Error('Not playable'), audio);
         return;
       }
-      const dispatcher = this.dispatcher = this.connection.play(audio.resource, audio.options);
-      let timeout = null;
-      if (audio.timeout > 0) timeout = setTimeout(() => dispatcher.end(), audio.timeout);
-      dispatcher.on('error', (...args) => {
-        dispatcher.end();
-        this.emit('error', ...args);
-      });
-      dispatcher.on('start', () => {
-        this.playing = audio;
-        audio.emit('start', this.channel, this.connection, dispatcher);
-      });
-      dispatcher.on('finish', () => {
-        if (timeout) clearTimeout(timeout);
-        this.playing = null;
-        this.dispatcher = null;
-        audio.emit('end', this.channel, this.connection);
-        done(null, audio);
-      });
+      (async () => {
+        try {
+          if (this.connection.sockets.ws.ws.readyState !== WebSocket.OPEN) {
+            const channel = this.channel;
+            this.leave();
+            await utils.wait(3000);
+            const res = await this.join(channel);
+            this.emit('warn', `WebSocket recovered ${channel.id} ${res}`);
+            await utils.wait(3000);
+            if (this.connection.sockets.ws.ws.readyState !== WebSocket.OPEN) {
+              throw new Error(`WebSocket failed to recover ${channel.id}`);
+            }
+          }
+          const dispatcher = this.dispatcher = this.connection.play(audio.resource, audio.options);
+          let timeout = null;
+          if (audio.timeout > 0) timeout = setTimeout(() => dispatcher.end(), audio.timeout);
+          dispatcher.on('error', (...args) => {
+            dispatcher.end();
+            this.emit('error', ...args);
+          });
+          dispatcher.on('start', () => {
+            this.playing = audio;
+            audio.emit('start', this.channel, this.connection, dispatcher);
+          });
+          dispatcher.on('finish', () => {
+            if (timeout) clearTimeout(timeout);
+            this.playing = null;
+            this.dispatcher = null;
+            audio.emit('end', this.channel, this.connection);
+            done(null, audio);
+          });
+        } catch (e) {
+          this.leave();
+          this.emit('error', e);
+          done(e, audio);
+        }
+      })();
     }, 1);
     this.queue.drain = () => this.playing = null;
   }
@@ -90,8 +111,8 @@ class VoiceChannel extends EventEmitter {
 
   play(audio, done) {
     if (!this.isPlayable()) return false;
-    this.queue.push(audio, done);
     this.emit('queue', audio, this.channel, this.connection);
+    this.queue.push(audio, done);
     return true;
   }
 


### PR DESCRIPTION
Here is the error log.

```
[DEBUG] Error [WS_NOT_OPEN]: Websocket not open to send ...
at /home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/networking/VoiceWebSocket.js:93:68
at new Promise (<anonymous>)
at VoiceWebSocket.send (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/networking/VoiceWebSocket.js:92:12)
at VoiceWebSocket.sendPacket (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/networking/VoiceWebSocket.js:112:17)
at VoiceConnection.setSpeaking (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/VoiceConnection.js:153:8)
at StreamDispatcher._setSpeaking (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/dispatcher/StreamDispatcher.js:303:35)
at StreamDispatcher._sendPacket (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/dispatcher/StreamDispatcher.js:290:10)
at StreamDispatcher._playChunk (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/dispatcher/StreamDispatcher.js:253:10)
at StreamDispatcher._write (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/dispatcher/StreamDispatcher.js:107:10)
at writeOrBuffer (internal/streams/writable.js:358:12) {
[Symbol(code)]: 'WS_NOT_OPEN'
}
```

It comes from,

https://github.com/discordjs/discord.js/blob/8a7abc9f06d44bf693e35a615bb6ba2c3eb1d6e7/src/client/voice/networking/VoiceWebSocket.js#L90-L99

WebSocket reconnection solves the problem, but why no connection here in the first place. The answer is:

```
[DEBUG] [WS] closed
[DEBUG] [WS] connect requested
[DEBUG] [WS] reset requested
[DEBUG] [WS] connecting, 5 attempts, wss://japan4233.discord.media/?v=4&encoding=json
[DEBUG] [WS] opened at gateway japan4233.discord.media
...
[DEBUG] [WS] closed
[DEBUG] [WS] connect requested
[DEBUG] [WS] reset requested
[DEBUG] Error [VOICE_CONNECTION_ATTEMPTS_EXCEEDED]: Too many connection attempts (5).
at VoiceWebSocket.connect (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/voice/networking/VoiceWebSocket.js:67:26)
at Timeout._onTimeout (/home/kanata/projects/knt2-dbot/node_modules/discord.js/src/client/BaseClient.js:83:7)
at listOnTimeout (internal/timers.js:554:17)
at processTimers (internal/timers.js:497:7) {
[Symbol(code)]: 'VOICE_CONNECTION_ATTEMPTS_EXCEEDED'
}
```

When your bot in a voice channel for long time, days or weeks, it encounters the retry limit.

https://github.com/discordjs/discord.js/blob/8a7abc9f06d44bf693e35a615bb6ba2c3eb1d6e7/src/client/voice/networking/VoiceWebSocket.js#L66-L69

It emits the debug event only. I assume that handling at the debug event is a typical bad practice. So, I decided to reset the retry counter every 10 mins. I know it's not a good practice either but I'd say it is better. It should work in most of cases. If it didn't work, it would re-join the voice channel before playing audio.